### PR TITLE
Add support for aarch64, ppc64le, s390/x

### DIFF
--- a/lib/Sys/Syscall.pm
+++ b/lib/Sys/Syscall.pm
@@ -48,6 +48,8 @@ our (
      $SYS_readahead,
      );
 
+our $no_deprecated = 0;
+
 if ($^O eq "linux") {
     # whether the machine requires 64-bit numbers to be on 8-byte
     # boundaries.
@@ -101,6 +103,14 @@ if ($^O eq "linux") {
         $SYS_epoll_wait   = 409;
         $SYS_readahead    = 379;
         $u64_mod_8        = 1;
+    } elsif ($machine eq "aarch64") {
+        $SYS_epoll_create = 20;  # (sys_epoll_create1)
+        $SYS_epoll_ctl    = 21;
+        $SYS_epoll_wait   = 22;  # (sys_epoll_pwait)
+        $SYS_sendfile     = 71;  # (sys_sendfile64)
+        $SYS_readahead    = 213;
+        $u64_mod_8        = 1;
+        $no_deprecated    = 1;
     } elsif ($machine =~ m/arm(v\d+)?.*l/) {
         # ARM OABI
         $SYS_epoll_create = 250;
@@ -203,7 +213,7 @@ sub epoll_defined { return $SYS_epoll_create ? 1 : 0; }
 # size doesn't even matter (radix tree now, not hash)
 sub epoll_create {
     return -1 unless defined $SYS_epoll_create;
-    my $epfd = eval { syscall($SYS_epoll_create, ($_[0]||100)+0) };
+    my $epfd = eval { syscall($SYS_epoll_create, $no_deprecated ? 0 : ($_[0]||100)+0) };
     return -1 if $@;
     return $epfd;
 }
@@ -241,7 +251,12 @@ sub epoll_wait_mod8 {
         $epoll_wait_size = $_[1];
         $epoll_wait_events = "\0" x 16 x $epoll_wait_size;
     }
-    my $ct = syscall($SYS_epoll_wait, $_[0]+0, $epoll_wait_events, $_[1]+0, $_[2]+0);
+    my $ct;
+    if ($no_deprecated) {
+        $ct = syscall($SYS_epoll_wait, $_[0]+0, $epoll_wait_events, $_[1]+0, $_[2]+0, undef);
+    } else {
+        $ct = syscall($SYS_epoll_wait, $_[0]+0, $epoll_wait_events, $_[1]+0, $_[2]+0);
+    }
     for ($_ = 0; $_ < $ct; $_++) {
         # 16 byte epoll_event structs, with format:
         #    4 byte mask [idx 1]

--- a/lib/Sys/Syscall.pm
+++ b/lib/Sys/Syscall.pm
@@ -65,7 +65,7 @@ if ($^O eq "linux") {
         $SYS_epoll_wait   = 232;
         $SYS_sendfile     =  40;
         $SYS_readahead    = 187;
-    } elsif ($machine eq "ppc64") {
+    } elsif ($machine =~ m/^ppc64/) {
         $SYS_epoll_create = 236;
         $SYS_epoll_ctl    = 237;
         $SYS_epoll_wait   = 238;

--- a/lib/Sys/Syscall.pm
+++ b/lib/Sys/Syscall.pm
@@ -79,6 +79,13 @@ if ($^O eq "linux") {
         $SYS_sendfile     = 186;  # sys_sendfile64=226
         $SYS_readahead    = 191;
         $u64_mod_8        = 1;
+    } elsif ($machine =~ m/^s390/) {
+        $SYS_epoll_create = 249;
+        $SYS_epoll_ctl    = 250;
+        $SYS_epoll_wait   = 251;
+        $SYS_sendfile     = 187;  # sys_sendfile64=223
+        $SYS_readahead    = 222;
+        $u64_mod_8        = 1;
     } elsif ($machine eq "ia64") {
         $SYS_epoll_create = 1243;
         $SYS_epoll_ctl    = 1244;


### PR DESCRIPTION
These patches add the appropriate support for these architectures, without which the testsuite fails due to `$u64_mod_8` not being set in the fallback.  These were tested on Fedora:

http://arm.koji.fedoraproject.org/koji/taskinfo?taskID=3310339
http://ppc.koji.fedoraproject.org/koji/taskinfo?taskID=2964517
http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=1996382
